### PR TITLE
doc/debian: Bump Tor to 0.3.4.x

### DIFF
--- a/docs/en/debian.wml
+++ b/docs/en/debian.wml
@@ -20,9 +20,8 @@ Debian Buster - testing, or Debian Sid - unstable</a></h2>
 <br />
 
 <p>
-If you're using Debian, just run
+If you're using Debian, just run as root:
 </blockquote><pre>  apt install tor </pre></blockquote>
-as root.
 </p>
 
 <p>Debian provides the <a href="https://packages.debian.org/stretch/tor">LTS</a>
@@ -32,9 +31,9 @@ that you're running the latest stable version of Tor, see option two below.
 </p>
 
 <p>
-Now Tor is installed and running. Move on to <a href="<page
-docs/tor-doc-unix>#using">step two</a> of the "Tor on Linux/Unix"
-instructions.
+When Tor is installed and running move on to <a href="<page
+docs/tor-doc-unix>#using">step two</a> of the "<a href="<page
+docs/tor-doc-unix>">Tor on Linux/Unix</a>" instructions.
 </p>
 
 <hr />
@@ -94,12 +93,18 @@ version
 </pre></blockquote>
 </div>
 
-<p>Please note that the <a href="https://packages.debian.org/stretch/apt-transport-https">apt-transport-https package</a> is required to enable the usage of 'deb https://foo distro main' lines in the /etc/apt/sources.list so that all package managers using the libapt-pkg library can access metadata and packages available in sources accessible over https (Hypertext Transfer Protocol Secure).</p>
+<p>Note: To use this source line in <i>/etc/apt/sources.list</i> The <a
+href="https://packages.debian.org/stretch/apt-transport-https">apt-transport-https
+package</a> is required. Install it with
+<blockquote><pre>
+apt install apt-transport-https
+</pre></blockquote>
+to enable the usage of 'deb https://foo distro main' lines in the /etc/apt/sources.list so that all package managers using the libapt-pkg library can access metadata and packages available in sources accessible over https (Hypertext Transfer Protocol Secure).</p>
 
 <div id="sig">
 <p>Then add the gpg key used to sign the packages by running the following commands at your command prompt:</p>
 <blockquote><pre>
-gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+gpg --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
 gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
 </pre></blockquote>
 </div>
@@ -148,7 +153,7 @@ in place of &lt;DISTRIBUTION&gt;.
 Then add the gpg key used to sign the packages by running the following
 commands at your command prompt:
 <pre style="margin: 1.5em 0 1.5em 2em">
-gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+gpg --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
 gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
 </pre>
 Now refresh your sources, running the following command (as root) at your
@@ -211,7 +216,7 @@ download/download-unix>#packagediff">development branch</a> of Tor instead
 to your <tt>/etc/apt/sources.list</tt> file:<br />
 <pre style="margin: 1.5em 0 1.5em 2em">
 deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb     https://deb.torproject.org/torproject.org tor-experimental-0.3.3.x-&lt;DISTRIBUTION&gt; main
+deb     https://deb.torproject.org/torproject.org tor-experimental-0.3.4.x-&lt;DISTRIBUTION&gt; main
 </pre>
 where you again substitute the name of your distro (stretch, buster,
 sid, xenial, ...) in place of
@@ -221,7 +226,7 @@ sid, xenial, ...) in place of
 <p>
 Then run the following commands at your command prompt:
 <pre style="margin: 1.5em 0 1.5em 2em">
-gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+gpg --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
 gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
 apt update
 apt install tor deb.torproject.org-keyring
@@ -249,7 +254,7 @@ deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
 
 # For the unstable version.
 deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb-src https://deb.torproject.org/torproject.org tor-experimental-0.3.3.x-&lt;DISTRIBUTION&gt; main
+deb-src https://deb.torproject.org/torproject.org tor-experimental-0.3.4.x-&lt;DISTRIBUTION&gt; main
 </pre>
 Substitute the name of your distro (stretch, buster, sid, xenial, ...) in place of &lt;DISTRIBUTION&gt;. Now refresh your sources by running (as root):
 <pre style="margin: 1.5em 0 1.5em 2em">


### PR DESCRIPTION
  - explain how to install apt-transport-https
  - fixes #26474
  - fixes #27094