### PR TITLE
WIP .well-known/security.txt

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,12 @@
+# https://www.torproject.org/about/contact#security
+Contact: tor-security@lists.torproject.org
+Encryption: openpgp4fpr:8B904624C5A28654E4539BC2E135A8B41A7BF184
+Acknowledgments: https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/SecurityPolicy
+
+Policy: https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/SecurityPolicy
+Hiring: https://www.torproject.org/about/jobs
+
+Permission: None
+
+# RFC-URL: https://tools.ietf.org/html/draft-foudil-securitytxt-04
+Signature: https://torproject.org/.well-known/security.txt.sig

--- a/about/en/contact.wml
+++ b/about/en/contact.wml
@@ -115,6 +115,7 @@ uid                  tor-security@lists.torproject.org <tor-security-owner@lists
 uid                  tor-security@lists.torproject.org <tor-security-request@lists.torproject.org>
 sub   4096R/C00942E4 2017-03-13
 </pre></blockquote>
+    Find links to <a href="https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/SecurityPolicy">acknowledgments and our security policy</a> in machine readable form at <a href="">https://torproject.org/.well-known/security.txt</a>.
     </p>
 
     <a id="badrelays"></a>


### PR DESCRIPTION
[#25131](https://trac.torproject.org/projects/tor/ticket/25131)

# Why

- [With the eyes of a security researcher](https://troyhunt.com/streamlining-data-breach-disclosures-a-step-by-step-process/)

# Draft
[Version 4](https://tools.ietf.org/html/draft-foudil-securitytxt-04) still has some nits and expires in January 2019.
```
# https://www.torproject.org/about/contact#security
Contact: tor-security@lists.torproject.org
Encryption: openpgp4fpr:8B904624C5A28654E4539BC2E135A8B41A7BF184
Acknowledgments: https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/SecurityPolicy

Policy: https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/SecurityPolicy
Hiring: https://www.torproject.org/about/jobs

Permission: None

# RFC-URL: https://tools.ietf.org/html/draft-foudil-securitytxt-04
Signature: https://torproject.org/.well-known/security.txt.sig
```

There's an ([incomplete](tomnomnom/securitytxt/issues/1)) validator written in Go.

# Comments

- Encryption: There are several options (see RFC url above). The key may be made available on the Torproject website (for example torproject.org/about/torproject.asc or torproject.org/.well-known/torproject-public-key.asc), be referenced as above or with dns:...

- [ ] Policy: the current security policy is a draft and should be published in a (signed) blog post (#5489) and linked from torproject.org/about/contact#security

- [ ] Hiring: it could help the Torproject to always have an open position for security researchers

- [ ] Signature: To signing the deb.torproject.org archive signing key (8B904624C5A28654E4539BC2E135A8B41A7BF184) can be used. The standard states:

>   When it comes to verifying the authenticity of the key, it is always
>   the security researcher's responsibility to make sure the key being
>   specified is indeed one they trust.  Researchers MUST NOT assume that
>   this key is used to generate the signature file referenced in
>   Section 3.4.7.


# Adoption
```
https://1password.com/.well-known/security.txt
https://www.google.com/.well-known/security.txt
https://protonmail.com/.well-known/security.txt
https://www.dropbox.com/.well-known/security.txt
https://www.jamieweb.net/.well-known/security.txt
https://www.facebook.com/.well-known/security.txt
https://scotthelme.co.uk/.well-known/security.txt
```

[who else?](https://www.exploit-db.com/ghdb/4793/ )

## 404
```
https://www.cloudflare.com/.well-known/security.txt
https://www.microsoft.com/.well-known/security.txt
https://www.schneier.com/.well-known/security.txt
https://www.kernel.org/.well-known/security.txt
https://www.debian.org/.well-known/security.txt
https://www.linux.org/.well-known/security.txt
https://www.nsa.gov/.well-known/security.txt
https://riseup.net/.well-known/security.txt
https://github.com/.well-known/security.txt
https://www.ibm.com/.well-known/security.txt
https://www.w3.org/.well-known/security.txt
https://gmail.com/.well-known/security.txt
```

The rails team [decided against this practice](rails/rails/pull/30829) and uses https://guides.rubyonrails.org/security.html instead (which is something else but also nice to have).

[:)](https://news.netcraft.com/archives/2018/01/29/the-hidden-well-known-phishing-sites.html)

# Next

- https://eff.org/.well-known/dnt-policy.txt

- [other .well-known URIs](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml)