### PR TITLE
getinvolved: change bug tracker link to not require login (#27412)

### DIFF
--- a/getinvolved/en/volunteer.wml
+++ b/getinvolved/en/volunteer.wml
@@ -349,8 +349,8 @@ meetings around the world.</li>
     <br /><br />
 
     <a id="project-tor"></a>
-    <h3>Tor (<a href="https://gitweb.torproject.org/tor.git">code</a>, <a
-    href="https://trac.torproject.org/projects/tor/report/12">bug
+    <h3>Tor (<a href="https://gitweb.torproject.org/tor.git">code</a>,
+    <a href="https://trac.torproject.org/projects/tor/query?status=accepted&status=assigned&status=needs_information&status=needs_review&status=needs_revision&status=new&status=reopened&component=Core+Tor%2FTor&or&status=accepted&status=assigned&status=needs_information&status=needs_review&status=needs_revision&status=new&status=reopened&component=Applications%2FTor+bundles%2Finstallation&group=milestone&col=id&col=summary&col=component&col=owner&col=type&col=priority&col=version&order=priority">bug
     tracker</a>)</h3>
 
     <p>


### PR DESCRIPTION
The bug tracker link to Tor on ​https://www.torproject.org/getinvolved/volunteer.html.en requires a trac account. It is very unlikely that anyone visiting this page for the first time (like after clicking "Get Involved" on about:tor) is logged in. This longer link gives the same result without login.