### PR TITLE
WIP debian guide: Remove experimental branch from js

### DIFF
--- a/docs/debian-selector.js
+++ b/docs/debian-selector.js
@@ -14,17 +14,6 @@ var software = {
                      'bionic':  [ 'bionic'],
                      'cosmic':  [ 'cosmic'],
                      },
-         'experimental-0.3.5.x': {
-                     'jessie':  [ 'jessie' ],
-                     'stretch': [ 'stretch' ],
-                     'buster':  [ 'buster' ],
-                     'sid':     [ 'sid' ],
-                     'trusty':  [ 'trusty'],
-                     'xenial':  [ 'xenial'],
-                     'artful':  [ 'artful'],
-                     'bionic':  [ 'bionic'],
-                     'cosmic':  [ 'cosmic'],
-                     },
          'nightly-master': {
                      'jessie':  [ 'jessie' ],
                      'stretch': [ 'stretch' ],
@@ -39,17 +28,6 @@ var software = {
        },
 'tor (from source)': {
          '_stable': {
-                     'jessie':  [ 'jessie' ],
-                     'stretch': [ 'stretch' ],
-                     'buster':  [ 'buster' ],
-                     'sid':     [ 'sid' ],
-                     'trusty':  [ 'trusty'],
-                     'xenial':  [ 'xenial'],
-                     'artful':  [ 'artful'],
-                     'bionic':  [ 'bionic'],
-                     'cosmic':  [ 'cosmic'],
-                     },
-         'experimental-0.3.5.x': {
                      'jessie':  [ 'jessie' ],
                      'stretch': [ 'stretch' ],
                      'buster':  [ 'buster' ],

--- a/docs/debian-selector.js
+++ b/docs/debian-selector.js
@@ -12,8 +12,9 @@ var software = {
                      'xenial':  [ 'xenial'],
                      'artful':  [ 'artful'],
                      'bionic':  [ 'bionic'],
+                     'cosmic':  [ 'cosmic'],
                      },
-         'experimental-0.3.4.x': {
+         'experimental-0.3.5.x': {
                      'jessie':  [ 'jessie' ],
                      'stretch': [ 'stretch' ],
                      'buster':  [ 'buster' ],
@@ -22,6 +23,7 @@ var software = {
                      'xenial':  [ 'xenial'],
                      'artful':  [ 'artful'],
                      'bionic':  [ 'bionic'],
+                     'cosmic':  [ 'cosmic'],
                      },
          'nightly-master': {
                      'jessie':  [ 'jessie' ],
@@ -32,6 +34,7 @@ var software = {
                      'xenial':  [ 'xenial'],
                      'artful':  [ 'artful'],
                      'bionic':  [ 'bionic'],
+                     'cosmic':  [ 'cosmic'],
                      },
        },
 'tor (from source)': {
@@ -44,8 +47,9 @@ var software = {
                      'xenial':  [ 'xenial'],
                      'artful':  [ 'artful'],
                      'bionic':  [ 'bionic'],
+                     'cosmic':  [ 'cosmic'],
                      },
-         'experimental-0.3.4.x': {
+         'experimental-0.3.5.x': {
                      'jessie':  [ 'jessie' ],
                      'stretch': [ 'stretch' ],
                      'buster':  [ 'buster' ],
@@ -54,6 +58,7 @@ var software = {
                      'xenial':  [ 'xenial'],
                      'artful':  [ 'artful'],
                      'bionic':  [ 'bionic'],
+                     'cosmic':  [ 'cosmic'],
                      },
        },
 };

--- a/docs/en/debian.wml
+++ b/docs/en/debian.wml
@@ -2,6 +2,14 @@
 # Revision: $Revision$
 # Translation-Priority: 3-low
 
+<:
+sub development_branch {
+  ($_) = "<alpha_version>";
+  s/\.\d$/.x/;
+  return $_;
+}
+:>
+
 #include "head.wmi" TITLE="Tor Project: Debian/Ubuntu Instructions" CHARSET="UTF-8"
 {#meta#:
 <script type="text/javascript" src="debian-selector.js"></script>
@@ -175,16 +183,6 @@ deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
 where you put the codename of your distribution (i.e. stretch, buster, sid
 or whatever it is) in place of &lt;DISTRIBUTION&gt;.
 </p>
-<p>
-If you want to use the
-<a href="<page download/download-unix>#packagediff">development branch</a>
-of Tor instead (more features and more bugs), you need add a different set of
-lines to your <i>/etc/apt/sources.list</i> file:<br />
-<pre>
-deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb     https://deb.torproject.org/torproject.org tor-experimental-<development-branch>-&lt;DISTRIBUTION&gt; main
-</pre>
-</p>
 
 <p>
 Then add the gpg key used to sign the packages by running the following
@@ -210,6 +208,16 @@ recommended you use it. Install it together with tor:
 </p>
 
 </noscript>
+<p>
+If you want to use the
+<a href="<page download/download-unix>#packagediff">development branch</a>
+of Tor instead (more features and more bugs), you need add a different set of
+lines to your <i>/etc/apt/sources.list</i> file:<br />
+<pre>
+deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
+deb     https://deb.torproject.org/torproject.org tor-experimental-<:= development_branch() :>-&lt;DISTRIBUTION&gt; main
+</pre>
+</p>
 <noscript>
 
 <hr />
@@ -227,7 +235,7 @@ deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
 
 &num; For the unstable version.
 deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb-src https://deb.torproject.org/torproject.org tor-experimental-<development-branch>-&lt;DISTRIBUTION&gt; main
+deb-src https://deb.torproject.org/torproject.org tor-experimental-<:= development_branch() :>-&lt;DISTRIBUTION&gt; main
 </pre>
 
 <p>

--- a/docs/en/debian.wml
+++ b/docs/en/debian.wml
@@ -169,22 +169,21 @@ $ cd ..
 <noscript>
 <p>
 Then add this line to your <tt>/etc/apt/sources.list</tt> file:<br />
-<blockquote><pre>
+<pre>
 deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-</pre></blockquote>
+</pre>
 where you put the codename of your distribution (i.e. stretch, buster, sid
 or whatever it is) in place of &lt;DISTRIBUTION&gt;.
 </p>
-
 <p>
 If you want to use the
 <a href="<page download/download-unix>#packagediff">development branch</a>
 of Tor instead (more features and more bugs), you need add a different set of
 lines to your <i>/etc/apt/sources.list</i> file:<br />
-<blockquote><pre>
+<pre>
 deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb     https://deb.torproject.org/torproject.org tor-experimental-0.3.5.x-&lt;DISTRIBUTION&gt; main
-</pre></blockquote>
+deb     https://deb.torproject.org/torproject.org tor-experimental-<development-branch>-&lt;DISTRIBUTION&gt; main
+</pre>
 </p>
 
 <p>
@@ -222,14 +221,15 @@ recommended you use it. Install it together with tor:
 If you want to build your own debs from source you must first add an
 appropriate <tt>deb-src</tt> line to <tt>sources.list</tt>.
 </p>
-<blockquote><pre>
+<pre>
 &num; For the stable version.
 deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
 
 &num; For the unstable version.
-deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb-src https://deb.torproject.org/torproject.org tor-experimental-0.3.5.x-&lt;DISTRIBUTION&gt; main
-</pre></blockquote>
+deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
+deb-src https://deb.torproject.org/torproject.org tor-experimental-<development-branch>-&lt;DISTRIBUTION&gt; main
+</pre>
+
 <p>
 Substitute the name of your distro (stretch, buster, sid, xenial, ...) in
 place of &lt;DISTRIBUTION&gt;. Now refresh your sources by running (as root):
@@ -297,15 +297,16 @@ To use Apt with Tor the according apt transport needs to be installed:
 </pre></blockquote>
 
 <p>
-Then replace the address in the lines added before with, for example:
+Then you can use tor:// and tor+https:// with any address, for example:
 </p>
-<blockquote><pre>
+<pre>
 &num; For the stable version.
 deb tor://sdscoq7snqtznauu.onion/torproject.org &lt;DISTRIBUTION&gt; main
 
 &num; For the unstable version.
+deb tor://sdscoq7snqtznauu.onion/torproject.org &lt;DISTRIBUTION&gt; main
 deb tor://sdscoq7snqtznauu.onion/torproject.org tor-nightly-master-&lt;DISTRIBUTION&gt; main
-</pre></blockquote>
+</pre>
 <p>
 Now refresh your sources and try if it's still possible to install tor:
 </p>

--- a/docs/en/debian.wml
+++ b/docs/en/debian.wml
@@ -315,6 +315,11 @@ Now refresh your sources and try if it's still possible to install tor:
 &num; apt install tor
 </pre></blockquote>
 <p>
+The <a href="https://salsa.debian.org/apt-team/apt-transport-tor/raw/master/README.md">
+README</a> of apt-transport-tor has more information for example how to use
+another SocksPort.
+</p>
+<p>
 See <a href="https://onion.torproject.org/">onion.torproject.org</a>
 for all torproject.org onion addresses.</p>
 </p>

--- a/docs/en/debian.wml
+++ b/docs/en/debian.wml
@@ -183,7 +183,7 @@ of Tor instead (more features and more bugs), you need add a different set of
 lines to your <i>/etc/apt/sources.list</i> file:<br />
 <blockquote><pre>
 deb     https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb     https://deb.torproject.org/torproject.org tor-experimental-0.3.4.x-&lt;DISTRIBUTION&gt; main
+deb     https://deb.torproject.org/torproject.org tor-experimental-0.3.5.x-&lt;DISTRIBUTION&gt; main
 </pre></blockquote>
 </p>
 
@@ -228,7 +228,7 @@ deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
 
 &num; For the unstable version.
 deb-src https://deb.torproject.org/torproject.org &lt;DISTRIBUTION&gt; main
-deb-src https://deb.torproject.org/torproject.org tor-experimental-0.3.4.x-&lt;DISTRIBUTION&gt; main
+deb-src https://deb.torproject.org/torproject.org tor-experimental-0.3.5.x-&lt;DISTRIBUTION&gt; main
 </pre></blockquote>
 <p>
 Substitute the name of your distro (stretch, buster, sid, xenial, ...) in


### PR DESCRIPTION
#54 introduced a change to `include/versions.wmi` to dynamically update the development branch in the debian guide. However this doesn't work for the javascript file. Instead this branch changes the howto to no longer show the development branch in the javascript selector but instead in the static part between the blocks changed by the script and it updates the sources.list snippet for the development branch from the beta variable in `include/versions.wmi`:
`<define-tag version-alpha whitespace=delete>0.3.5.7</define-tag>`