### PR TITLE
Removed false legal claim

### DIFF
--- a/docs/en/faq.wml
+++ b/docs/en/faq.wml
@@ -374,8 +374,7 @@
     <dt>Doesn't the first server see who I am?</dt>
     <dd>Possibly. A bad first of three servers can see encrypted Tor traffic
     coming from your computer. It still doesn't know who you are and what you
-    are doing over Tor.  It merely sees "This IP address is using Tor".  Tor is
-    not illegal anywhere in the world, so using Tor by itself is fine.  You are
+    are doing over Tor.  It merely sees "This IP address is using Tor".  You are
     still protected from this node figuring out both who you are and where you
     are going on the Internet.
     </dd>


### PR DESCRIPTION
While it might be good for a separate page to show the legal status of Tor in various countries based on existing laws, until such a page offers such comparisons, I believe it would be best if the claim of not being illegal in any countries (false) is simply removed as it provides no additional value in context to the section anyway.

Additional arguments, discussion, and sources are seen in his thread https://www.reddit.com/r/TOR/comments/eeesu6/dangerously_misleading_information_on_the_tor/